### PR TITLE
Vulnerability and bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.4</version>
+            <version>4.5.13</version>
         </dependency>
         <!--  <dependency>
              <groupId>dom4j</groupId>
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.2	</version>
+            <version>2.12.3	</version>
         </dependency>
 	    <dependency>
 			<groupId>com.sun.xml.parsers</groupId>
@@ -355,6 +355,14 @@
                     <artifactId>xml-apis</artifactId>
             </exclusion>
             
+            <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+            </exclusion>
+            <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-web</artifactId>
+            </exclusion>
                 <exclusion>
                     <artifactId>spring-web</artifactId>
                     <groupId>org.springframework</groupId>
@@ -381,7 +389,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        
         <dependency>
+             <groupId>io.netty</groupId>
+             <artifactId>netty-codec-http</artifactId>
+             <version>4.1.60.Final</version>
+            </dependency>
+        <dependency>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-web</artifactId>
+          <version>4.1.0.Beta1</version>
+         </dependency>
+         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -216,8 +216,17 @@
                     <groupId>org.apache.logging.log4j</groupId>
     				<artifactId>log4j-api</artifactId>
                 </exclusion>
+                <!-- exclusion>
+                    <groupId>org.acegisecurity</groupId>
+    				<artifactId>acegi-security</artifactId>
+                </exclusion-->
             </exclusions>
         </dependency>
+        <!-- dependency>
+           <groupId>org.acegisecurity</groupId>
+    	   <artifactId>acegi-security</artifactId>
+    	   <version>1.0.7</version>
+        </dependency-->
         <dependency>
          <groupId>com.jcraft</groupId>
          <artifactId>jsch</artifactId>
@@ -262,6 +271,17 @@
               <groupId>commons-fileupload</groupId>
               <artifactId>commons-fileupload</artifactId>
               <version>1.4</version>
+              <exclusions>
+              <exclusion>
+              	<groupId>commons-io</groupId>
+            	<artifactId>commons-io</artifactId>
+            	</exclusion>
+              </exclusions>
+         </dependency>
+         <dependency>
+         	<groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.8.0</version>
          </dependency>
         <dependency>
     		<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx</groupId>
     <artifactId>checkmarx-bamboo-plugin</artifactId>
-    <version>2021.2.32</version>
+    <version>2021.2.33</version>
     <organization>
         <name>Checkmarx LTD</name>
         <url>http://www.checkmarx.com/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -171,11 +171,22 @@
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
                 </exclusion>
-                
                 <exclusion>
                     <groupId>com.thoughtworks.xstream</groupId>
                     <artifactId>xstream</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.igniterealtime.smack</groupId>
+                    <artifactId>smack-core</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>org.igniterealtime.smack</groupId>
+            		<artifactId>smack-tcp</artifactId>
+            	</exclusion>
                 <!--<exclusion>-->
                 <!--<groupId>commons-fileupload</groupId>-->
                 <!--<artifactId>commons-fileupload</artifactId>-->
@@ -207,6 +218,26 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+         <groupId>com.jcraft</groupId>
+         <artifactId>jsch</artifactId>
+         <version>0.1.55</version>
+        </dependency>
+         <dependency>
+           <groupId>org.apache.activemq</groupId>
+           <artifactId>activemq-broker</artifactId>
+           <version>5.16.1</version>
+         </dependency>
+         <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-core</artifactId>
+            <version>4.4.2</version>
+         </dependency>
+         <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-tcp</artifactId>
+            <version>4.4.2</version>
+         </dependency>
         <dependency>
            <artifactId>commons-collections4</artifactId>
            <groupId>org.apache.commons</groupId>
@@ -262,6 +293,10 @@
 	      		<groupId>com.fasterxml.jackson.core</groupId>
             	<artifactId>jackson-databind</artifactId>
 	     	</exclusion>
+	     	<exclusion>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>activemq-broker</artifactId>
+            </exclusion>
 	     	</exclusions>
         </dependency>
         <dependency>
@@ -394,11 +429,22 @@
              <groupId>io.netty</groupId>
              <artifactId>netty-codec-http</artifactId>
              <version>4.1.60.Final</version>
-            </dependency>
+        </dependency>
+        <dependency>
+             <groupId>io.netty</groupId>
+             <artifactId>netty-codec-http2</artifactId>
+             <version>4.1.63.Final</version>
+        </dependency>
         <dependency>
           <groupId>io.vertx</groupId>
           <artifactId>vertx-web</artifactId>
           <version>4.1.0.Beta1</version>
+          <exclusions>
+	          <exclusion>
+	            <groupId>io.netty</groupId>
+	            <artifactId>netty-codec-http2</artifactId>
+	          </exclusion>
+          </exclusions>
          </dependency>
          <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx</groupId>
     <artifactId>checkmarx-bamboo-plugin</artifactId>
-    <version>2021.2.31</version>
+    <version>2021.2.32</version>
     <organization>
         <name>Checkmarx LTD</name>
         <url>http://www.checkmarx.com/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
        
-        <common.client.version>2021.1.153</common.client.version>
+        <common.client.version>2021.2.159</common.client.version>
+
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -121,6 +122,26 @@
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-cbor</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                    <groupId>org.bouncycastle</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jms</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                    <groupId>org.bouncycastle</groupId>
+                </exclusion>
+                 <exclusion>
+                    <artifactId>commons-collections4</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
 <!--                <exclusion>-->
 <!--                    <groupId>dom4j</groupId>-->
 <!--                    <artifactId>dom4j</artifactId>-->
@@ -146,6 +167,11 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk14</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                
                 <exclusion>
                     <groupId>com.thoughtworks.xstream</groupId>
                     <artifactId>xstream</artifactId>
@@ -182,6 +208,31 @@
             </exclusions>
         </dependency>
         <dependency>
+           <artifactId>commons-collections4</artifactId>
+           <groupId>org.apache.commons</groupId>
+           <version>4.4</version>
+        </dependency>
+         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.28</version>
+         </dependency>
+         <dependency>
+              <groupId>org.quartz-scheduler</groupId>
+              <artifactId>quartz</artifactId>
+              <version>2.3.2</version>
+         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jms</artifactId>
+            <version>5.3.5</version>
+        </dependency>
+         <dependency>
+              <groupId>commons-fileupload</groupId>
+              <artifactId>commons-fileupload</artifactId>
+              <version>1.4</version>
+         </dependency>
+        <dependency>
     		<groupId>org.apache.logging.log4j</groupId>
     		<artifactId>log4j-api</artifactId>
     			<version>2.14.0</version>
@@ -200,12 +251,23 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.2.11.RELEASE</version>
+            <version>5.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-mqtt</artifactId>
             <version>5.15.9</version>
+            <exclusions>
+            <exclusion>
+	      		<groupId>com.fasterxml.jackson.core</groupId>
+            	<artifactId>jackson-databind</artifactId>
+	     	</exclusion>
+	     	</exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.2	</version>
         </dependency>
 	    <dependency>
 			<groupId>com.sun.xml.parsers</groupId>
@@ -226,7 +288,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk14</artifactId>
-            <version>1.65</version>
+            <version>1.68</version>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>
@@ -312,10 +374,6 @@
                 <exclusion>
                     <artifactId>jersey-client</artifactId>
                     <groupId>com.sun.jersey</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                    <groupId>org.bouncycastle</groupId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/cx/plugin/configuration/AgentTaskConfigurator.java
+++ b/src/main/java/com/cx/plugin/configuration/AgentTaskConfigurator.java
@@ -596,13 +596,11 @@ public class AgentTaskConfigurator extends AbstractTaskConfigurator {
 
     private Map<String, String> generateCxOSAAndSCAFields(@NotNull final ActionParametersMap params, Map<String, String> config) {
         
-    	
-        		
-        config.put(CX_USE_CUSTOM_DEPENDENCY_SETTINGS,getDefaultString(params, CX_USE_CUSTOM_DEPENDENCY_SETTINGS).trim());		
+    	config.put(CX_USE_CUSTOM_DEPENDENCY_SETTINGS,getDefaultString(params, CX_USE_CUSTOM_DEPENDENCY_SETTINGS).trim());
+        config.put(ENABLE_DEPENDENCY_SCAN, getDefaultString(params, ENABLE_DEPENDENCY_SCAN).trim());
 		String useCustomdependencyScanSettings = getDefaultString(params, CX_USE_CUSTOM_DEPENDENCY_SETTINGS).trim();
 		if(!StringUtils.isEmpty(useCustomdependencyScanSettings) && useCustomdependencyScanSettings.equalsIgnoreCase("true")) {
-			final String configType = getDefaultString(params, DEPENDENCY_SCAN_TYPE);
-	    	config.put(ENABLE_DEPENDENCY_SCAN, getDefaultString(params, ENABLE_DEPENDENCY_SCAN).trim());
+			final String configType = getDefaultString(params, DEPENDENCY_SCAN_TYPE);	    	
 	        config.put(DEPENDENCY_SCAN_TYPE, configType);
 	        
 	        config.put(OSA_INSTALL_BEFORE_SCAN, getDefaultString(params, OSA_INSTALL_BEFORE_SCAN).trim());
@@ -618,8 +616,7 @@ public class AgentTaskConfigurator extends AbstractTaskConfigurator {
 			config.put(CXSCA_PWD,encrypt(getDefaultString(params, CXSCA_PWD).trim()));    
 			
 		}else {
-			final String configType = getAdminConfig(GLOBAL_DEPENDENCY_SCAN_TYPE);
-	    	config.put(ENABLE_DEPENDENCY_SCAN, getAdminConfig(GLOBAL_ENABLE_DEPENDENCY_SCAN).trim());
+			final String configType = getAdminConfig(GLOBAL_DEPENDENCY_SCAN_TYPE);	    	
 	        config.put(DEPENDENCY_SCAN_TYPE, configType);
 	        
 	        config.put(OSA_INSTALL_BEFORE_SCAN, getAdminConfig(GLOBAL_OSA_INSTALL_BEFORE_SCAN).trim());


### PR DESCRIPTION
•	Fixed issue where HTML report was not available in case of failure due to threshold exceeding.
•	Fixed UI issue that ‘Dependency Scan’ was shown as checked always.

Upgraded to higher versions of below libraries to fix security vulnerabilities:
•	org.apache.httpcomponents:httpclient 
•	com.jcraft:jsch
•	org.apache.activemq:activemq-broker
•	org.igniterealtime.smack:smack-core
•	org.igniterealtime.smack:smack-tcp
•	commons-collections4:org.apache.commons
•	org.yaml:snakeyaml
•	org.quartz-scheduler:quartz
•	org.springframework:spring-jms
•	commons-fileupload:commons-fileupload
•	commons-io:commons-io
•	com.fasterxml.jackson.core:jackson-databind
•	org.bouncycastle:bcprov-jdk14
•	io.netty:netty-codec-http
•	io.netty:netty-codec-http2
•	io.vertx:vertx-web