### PR TITLE
2024_Q1_Bug_Fixes: New parameter for SCA Policy Violation and bug fixes in bamboo plugin

### DIFF
--- a/src/main/java/com/cx/plugin/configuration/AgentTaskConfigurator.java
+++ b/src/main/java/com/cx/plugin/configuration/AgentTaskConfigurator.java
@@ -394,6 +394,7 @@ public class AgentTaskConfigurator extends AbstractTaskConfigurator {
             context.put(SCAN_CONTROL_SECTION, GLOBAL_CONFIGURATION_CONTROL);
             context.put(IS_SYNCHRONOUS, OPTION_TRUE);
             context.put(POLICY_VIOLATION_ENABLED, OPTION_FALSE);
+            context.put(POLICY_VIOLATION_ENABLED_SCA, OPTION_FALSE);
             context.put(THRESHOLDS_ENABLED, OPTION_FALSE);
             context.put(HIGH_THRESHOLD, "");
             context.put(MEDIUM_THRESHOLD, "");
@@ -406,6 +407,7 @@ public class AgentTaskConfigurator extends AbstractTaskConfigurator {
             context.put(SCAN_CONTROL_SECTION, configMap.get(SCAN_CONTROL_SECTION));
             context.put(IS_SYNCHRONOUS, configMap.get(IS_SYNCHRONOUS));
             context.put(POLICY_VIOLATION_ENABLED, configMap.get(POLICY_VIOLATION_ENABLED));
+            context.put(POLICY_VIOLATION_ENABLED_SCA, configMap.get(POLICY_VIOLATION_ENABLED_SCA));
             context.put(THRESHOLDS_ENABLED, configMap.get(THRESHOLDS_ENABLED));
             context.put(HIGH_THRESHOLD, configMap.get(HIGH_THRESHOLD));
             context.put(MEDIUM_THRESHOLD, configMap.get(MEDIUM_THRESHOLD));
@@ -418,6 +420,7 @@ public class AgentTaskConfigurator extends AbstractTaskConfigurator {
 
         context.put(GLOBAL_IS_SYNCHRONOUS, getAdminConfig(GLOBAL_IS_SYNCHRONOUS));
         context.put(GLOBAL_POLICY_VIOLATION_ENABLED, getAdminConfig(GLOBAL_POLICY_VIOLATION_ENABLED));
+        context.put(GLOBAL_POLICY_VIOLATION_ENABLED_SCA, getAdminConfig(GLOBAL_POLICY_VIOLATION_ENABLED_SCA));
         context.put(GLOBAL_THRESHOLDS_ENABLED, getAdminConfig(GLOBAL_THRESHOLDS_ENABLED));
         context.put(GLOBAL_HIGH_THRESHOLD, getAdminConfig(GLOBAL_HIGH_THRESHOLD));
         context.put(GLOBAL_MEDIUM_THRESHOLD, getAdminConfig(GLOBAL_MEDIUM_THRESHOLD));
@@ -482,6 +485,7 @@ public class AgentTaskConfigurator extends AbstractTaskConfigurator {
 
         config.put(IS_SYNCHRONOUS, params.getString(IS_SYNCHRONOUS));
         config.put(POLICY_VIOLATION_ENABLED, params.getString(POLICY_VIOLATION_ENABLED));
+        config.put(POLICY_VIOLATION_ENABLED_SCA, params.getString(POLICY_VIOLATION_ENABLED_SCA));
 
         config.put(IS_INCREMENTAL, params.getString(IS_INCREMENTAL));
         config.put(FORCE_SCAN, params.getString(FORCE_SCAN));

--- a/src/main/java/com/cx/plugin/configuration/CxGlobalConfig.java
+++ b/src/main/java/com/cx/plugin/configuration/CxGlobalConfig.java
@@ -37,6 +37,7 @@ public class CxGlobalConfig extends GlobalAdminAction {
     private String globalIsSynchronous;
     private String globalEnableProxy;
     private String globalEnablePolicyViolations;
+    private String globalEnablePolicyViolationsSCA;
     private String globalScanTimeoutInMinutes;
     private String globalThresholdsEnabled;
     private String globalHighThreshold;
@@ -119,6 +120,7 @@ public class CxGlobalConfig extends GlobalAdminAction {
         globalEnableProxy=adminConfig.getSystemProperty(GLOBAL_ENABLE_PROXY);
         globalHideResults = adminConfig.getSystemProperty(GLOBAL_HIDE_RESULTS);
         globalEnablePolicyViolations = adminConfig.getSystemProperty(GLOBAL_POLICY_VIOLATION_ENABLED);
+        globalEnablePolicyViolationsSCA = adminConfig.getSystemProperty(GLOBAL_POLICY_VIOLATION_ENABLED_SCA);
         globalThresholdsEnabled = adminConfig.getSystemProperty(GLOBAL_THRESHOLDS_ENABLED);
         globalHighThreshold = adminConfig.getSystemProperty(GLOBAL_HIGH_THRESHOLD);
         globalMediumThreshold = adminConfig.getSystemProperty(GLOBAL_MEDIUM_THRESHOLD);
@@ -194,8 +196,10 @@ public class CxGlobalConfig extends GlobalAdminAction {
             globalThresholdsEnabled = null;
             globalOsaThresholdsEnabled = null;
             globalEnablePolicyViolations = null;
+            globalEnablePolicyViolationsSCA = null;
         }
         adminConfig.setSystemProperty(GLOBAL_POLICY_VIOLATION_ENABLED, globalEnablePolicyViolations);
+        adminConfig.setSystemProperty(GLOBAL_POLICY_VIOLATION_ENABLED_SCA, globalEnablePolicyViolationsSCA);
         adminConfig.setSystemProperty(GLOBAL_THRESHOLDS_ENABLED, globalThresholdsEnabled);
         adminConfig.setSystemProperty(GLOBAL_HIGH_THRESHOLD, globalHighThreshold);
         adminConfig.setSystemProperty(GLOBAL_MEDIUM_THRESHOLD, globalMediumThreshold);
@@ -345,6 +349,14 @@ public class CxGlobalConfig extends GlobalAdminAction {
 
     public void setGlobalEnablePolicyViolations(String globalEnablePolicyViolations) {
         this.globalEnablePolicyViolations = globalEnablePolicyViolations;
+    }
+    
+    public String getGlobalEnablePolicyViolationsSCA() {
+        return globalEnablePolicyViolationsSCA;
+    }
+
+    public void setGlobalEnablePolicyViolationsSCA(String globalEnablePolicyViolationsSCA) {
+        this.globalEnablePolicyViolationsSCA = globalEnablePolicyViolationsSCA;
     }
 
     public void setGlobalIsSynchronous(String globalIsSynchronous) {

--- a/src/main/java/com/cx/plugin/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/utils/CxConfigHelper.java
@@ -18,6 +18,7 @@ import static com.cx.plugin.utils.CxParam.CXSCA_RESOLVER_PATH_GLOBAL;
 import static com.cx.plugin.utils.CxParam.CXSCA_USERNAME;
 import static com.cx.plugin.utils.CxParam.CXSCA_WEBAPP_URL;
 import static com.cx.plugin.utils.CxParam.CX_USE_CUSTOM_DEPENDENCY_SETTINGS;
+import static com.cx.plugin.utils.CxParam.GLOBAL_ENABLE_DEPENDENCY_SCAN;
 import static com.cx.plugin.utils.CxParam.DEPENDENCY_SCAN_FILTER_PATTERNS;
 import static com.cx.plugin.utils.CxParam.DEPENDENCY_SCAN_FOLDER_EXCLUDE;
 import static com.cx.plugin.utils.CxParam.DEPENDENCY_SCAN_TYPE;
@@ -51,6 +52,7 @@ import static com.cx.plugin.utils.CxParam.GLOBAL_OSA_LOW_THRESHOLD;
 import static com.cx.plugin.utils.CxParam.GLOBAL_OSA_MEDIUM_THRESHOLD;
 import static com.cx.plugin.utils.CxParam.GLOBAL_OSA_THRESHOLDS_ENABLED;
 import static com.cx.plugin.utils.CxParam.GLOBAL_POLICY_VIOLATION_ENABLED;
+import static com.cx.plugin.utils.CxParam.GLOBAL_POLICY_VIOLATION_ENABLED_SCA;
 import static com.cx.plugin.utils.CxParam.GLOBAL_PWD;
 import static com.cx.plugin.utils.CxParam.GLOBAL_SCAN_TIMEOUT_IN_MINUTES;
 import static com.cx.plugin.utils.CxParam.GLOBAL_SERVER_URL;
@@ -74,6 +76,7 @@ import static com.cx.plugin.utils.CxParam.OSA_MEDIUM_THRESHOLD;
 import static com.cx.plugin.utils.CxParam.OSA_THRESHOLDS_ENABLED;
 import static com.cx.plugin.utils.CxParam.PASSWORD;
 import static com.cx.plugin.utils.CxParam.POLICY_VIOLATION_ENABLED;
+import static com.cx.plugin.utils.CxParam.POLICY_VIOLATION_ENABLED_SCA;
 import static com.cx.plugin.utils.CxParam.PRESET_ID;
 import static com.cx.plugin.utils.CxParam.PRESET_NAME;
 import static com.cx.plugin.utils.CxParam.PROJECT_NAME;
@@ -255,6 +258,7 @@ public class CxConfigHelper {
         //add AST_SCA or OSA based on what user has selected
         ScannerType scannerType = null;
         if(resolveBool(configMap, ENABLE_DEPENDENCY_SCAN)) {
+        	
         	setDependencyScanEnabled(true);
         	String useCustomdependencyScanSettings = configMap.get(CX_USE_CUSTOM_DEPENDENCY_SETTINGS);
     		if(!StringUtils.isEmpty(useCustomdependencyScanSettings) && useCustomdependencyScanSettings.equalsIgnoreCase("true")) {
@@ -274,7 +278,10 @@ public class CxConfigHelper {
                     scanConfig.setOsaRunInstall(resolveBool(configMap, OSA_INSTALL_BEFORE_SCAN));
             	}
     		}else {
-    			setUsingGlobalDependencyScan(true);    			
+//    			setUsingGlobalDependencyScan(true);
+    			//Global level configurations for dependency scan are used only when "Enable Dependency Scan" checkbox is enabled in global configurations
+    			String useGlobalependencyScanSettings = getAdminConfig(GLOBAL_ENABLE_DEPENDENCY_SCAN);
+    			if(!StringUtils.isEmpty(useGlobalependencyScanSettings) && useGlobalependencyScanSettings.equalsIgnoreCase("true")) {
             	scanConfig.setOsaFilterPattern(getAdminConfig(GLOBAL_DEPENDENCY_SCAN_FILTER_PATTERNS));
             	scanConfig.setOsaFolderExclusions(getAdminConfig(GLOBAL_DEPENDENCY_SCAN_FOLDER_EXCLUDE));
             	if(getAdminConfig(GLOBAL_DEPENDENCY_SCAN_TYPE).equalsIgnoreCase(ScannerType.AST_SCA.toString())) {        		
@@ -289,6 +296,7 @@ public class CxConfigHelper {
                     scanConfig.setOsaArchiveIncludePatterns(getAdminConfig(GLOBAL_OSA_ARCHIVE_INCLUDE_PATTERNS));
                     scanConfig.setOsaRunInstall(resolveGlobalBool(GLOBAL_OSA_INSTALL_BEFORE_SCAN));
             	}
+    			}
     		}
     		
 
@@ -303,6 +311,7 @@ public class CxConfigHelper {
         	if (isCustomConfSect) { 
         		scanConfig.setSynchronous(resolveBool(configMap, IS_SYNCHRONOUS));
                 scanConfig.setEnablePolicyViolations(resolveBool(configMap, POLICY_VIOLATION_ENABLED));
+                scanConfig.setEnablePolicyViolationsSCA(resolveBool(configMap, POLICY_VIOLATION_ENABLED_SCA));
         		if(enableSAST) {
             scanConfig.setSastThresholdsEnabled(resolveBool(configMap, THRESHOLDS_ENABLED));
             scanConfig.setSastHighThreshold(resolveInt(configMap.get(HIGH_THRESHOLD), log));
@@ -318,6 +327,7 @@ public class CxConfigHelper {
         	else {
         		scanConfig.setSynchronous(resolveGlobalBool(GLOBAL_IS_SYNCHRONOUS));
                 scanConfig.setEnablePolicyViolations(resolveGlobalBool(GLOBAL_POLICY_VIOLATION_ENABLED));
+                scanConfig.setEnablePolicyViolationsSCA(resolveGlobalBool(GLOBAL_POLICY_VIOLATION_ENABLED_SCA));
         		if(enableSAST) {
             scanConfig.setSastThresholdsEnabled(resolveGlobalBool(GLOBAL_THRESHOLDS_ENABLED));
             scanConfig.setSastHighThreshold(resolveInt(getAdminConfig(GLOBAL_HIGH_THRESHOLD), log));

--- a/src/main/java/com/cx/plugin/utils/CxParam.java
+++ b/src/main/java/com/cx/plugin/utils/CxParam.java
@@ -43,6 +43,7 @@ public class CxParam {
     public static final String MEDIUM_THRESHOLD = "mediumThreshold";
     public static final String LOW_THRESHOLD = "lowThreshold";
     public static final String POLICY_VIOLATION_ENABLED = "enablePolicyViolations";
+    public static final String POLICY_VIOLATION_ENABLED_SCA = "enablePolicyViolationsSCA";
     public static final String OSA_ENABLED = "osaEnabled";
     public static final String DEPENDENCY_SCAN_FILTER_PATTERNS = "cxDependencyScanFilterPatterns";
     public static final String DEPENDENCY_SCAN_FOLDER_EXCLUDE = "cxDependencyScanfolderExclusions";
@@ -127,6 +128,7 @@ public class CxParam {
     public static final String IS_GLOBAL_HIDE_RESULTS = "isglobalHideResults";
     public static final String GLOBAL_HIDE_RESULTS = "globalHideResults";
     public static final String GLOBAL_POLICY_VIOLATION_ENABLED = "globalEnablePolicyViolations";
+    public static final String GLOBAL_POLICY_VIOLATION_ENABLED_SCA = "globalEnablePolicyViolationsSCA";
     public static final String DEFAULT_FILTER_PATTERNS = "!**/_cvs/**/*, !**/.svn/**/*,   !**/.hg/**/*,   !**/.git/**/*,  !**/.bzr/**/*, !**/bin/**/*," +
             "!**/obj/**/*,  !**/backup/**/*, !**/.idea/**/*, !**/*.DS_Store, !**/*.ipr,     !**/*.iws,   " +
             "!**/*.bak,     !**/*.tmp,       !**/*.aac,      !**/*.aif,      !**/*.iff,     !**/*.m3u,   !**/*.mid,   !**/*.mp3,  " +

--- a/src/main/java/com/cx/plugin/utils/CxPluginUtils.java
+++ b/src/main/java/com/cx/plugin/utils/CxPluginUtils.java
@@ -86,7 +86,8 @@ public abstract class CxPluginUtils {
             log.info("is force scan: " + config.getForceScan());
             log.info("Is generate full XML report: " + config.getGenerateXmlReport());
             log.info("Is generate PDF report: " + config.getGeneratePDFReport());
-            log.info("Policy violations enabled: " + config.getEnablePolicyViolations());
+            log.info("SAST and OSA Policy violations enabled: " + config.getEnablePolicyViolations());
+            log.info("SCA Policy violations enabled: " + config.getEnablePolicyViolationsSCA());
             log.info("Source code encoding id: " + config.getEngineConfigurationId());
             log.info("CxSAST thresholds enabled: " + config.getSastThresholdsEnabled());
             if (config.getSastThresholdsEnabled()) {
@@ -105,7 +106,7 @@ public abstract class CxPluginUtils {
         }
         
         log.info("Dependency Scan enabled : " + configBFF.isDependencyScanEnabled());        
-        if(configBFF.isDependencyScanEnabled()) {
+        if(config.isOsaEnabled() || config.isAstScaEnabled()) {
 	        log.info("Dependency Scan type : " + configBFF.getDependencyScanType().getDisplayName() );
 	        log.info("Dependency scan configuration:");
 	        log.info(" Folder exclusions: " + config.getOsaFolderExclusions());
@@ -119,6 +120,9 @@ public abstract class CxPluginUtils {
 	        if (config.isOsaEnabled()) {	            
 	            log.info(" CxOSA archive extract patterns: " + config.getOsaArchiveIncludePatterns());
 	            log.info(" Execute dependency managers 'install packages' command before CxOSA Scan: " + config.getOsaRunInstall());            
+	        } else if(config.isAstScaEnabled())	{
+	        	log.info(" CxSCA Tenant: " + config.getAstScaConfig().getTenant());
+	        	log.info(" CxSCA TeamPath: " + config.getAstScaConfig().getTeamPath());
 	        }	        
         }
 

--- a/src/main/resources/com/cx/plugin/cxGlobalConfig.ftl
+++ b/src/main/resources/com/cx/plugin/cxGlobalConfig.ftl
@@ -147,6 +147,7 @@
 
         [@ui.bambooSection dependsOn='globalIsSynchronous' showOn='true']
             [@ww.checkbox labelKey="enablePolicyViolations.label" name="globalEnablePolicyViolations" descriptionKey="enablePolicyViolations.description" toggle='true' /]
+            [@ww.checkbox labelKey="enablePolicyViolationsSCA.label" name="globalEnablePolicyViolationsSCA" descriptionKey="enablePolicyViolationsSCA.description" toggle='true' /]
             [@ww.checkbox labelKey="thresholdsEnabled.label" name="globalThresholdsEnabled" descriptionKey="thresholdsEnabled.description" toggle='true' /]
             [@ui.bambooSection dependsOn='globalThresholdsEnabled' showOn='true']
                 [@ww.textfield labelKey="sastHighThreshold.label" name="globalHighThreshold" required='false'/]

--- a/src/main/resources/com/cx/plugin/editExampleTask.ftl
+++ b/src/main/resources/com/cx/plugin/editExampleTask.ftl
@@ -272,6 +272,7 @@
         [@ui.bambooSection dependsOn='isSynchronous' showOn='true']
 
             [@ww.checkbox labelKey="enablePolicyViolations.label" name="enablePolicyViolations" descriptionKey="enablePolicyViolations.description" toggle='true' /]
+            [@ww.checkbox labelKey="enablePolicyViolationsSCA.label" name="enablePolicyViolationsSCA" descriptionKey="enablePolicyViolationsSCA.description" toggle='true' /]
 			[@ui.bambooSection dependsOn="enableSASTScan" showOn="true"]
             [@ww.checkbox labelKey="thresholdsEnabled.label" name="thresholdsEnabled" descriptionKey="thresholdsEnabled.description" toggle='true' /]
             [@ui.bambooSection dependsOn='thresholdsEnabled' showOn='true']
@@ -329,6 +330,13 @@
                 [@ww.checkbox labelKey="enablePolicyViolations.label" name="globalEnablePolicyViolations" descriptionKey="enablePolicyViolations.description" toggle='true' disabled="true" /]
             [/#if]
             
+            [#if (globalEnablePolicyViolationsSCA.attribute)??]
+                [@ww.checkbox labelKey="enablePolicyViolationsSCA.label" name="globalEnablePolicyViolationsSCA" descriptionKey="enablePolicyViolationsSCA.description" toggle='true' disabled="true" checked='true' /]
+
+            [#else]
+                [@ww.checkbox labelKey="enablePolicyViolationsSCA.label" name="globalEnablePolicyViolationsSCA" descriptionKey="enablePolicyViolationsSCA.description" toggle='true' disabled="true" /]    
+            [/#if]
+            
             [#if (globalThresholdsEnabled.attribute)??]            
                 [@ww.checkbox labelKey="thresholdsEnabled.label" name="globalThresholdsEnabled" descriptionKey="thresholdsEnabled.description" toggle='true' disabled="true" checked='true' /]
                 [@ww.label labelKey="sastHighThreshold.label" name="globalHighThreshold" /]
@@ -355,6 +363,7 @@
         [#else]
             [@ww.checkbox labelKey="isSynchronous.label" name="globalIsSynchronous" descriptionKey="isSynchronous.description" toggle='true' disabled="true" checked='false'/]
             [@ww.checkbox labelKey="enablePolicyViolations.label" name="globalEnablePolicyViolations" descriptionKey="enablePolicyViolations.description" toggle='true' disabled="true" checked='false'/]
+            [@ww.checkbox labelKey="enablePolicyViolationsSCA.label" name="globalEnablePolicyViolationsSCA" descriptionKey="enablePolicyViolationsSCA.description" toggle='true' disabled="true" checked='false'/]
             [@ui.bambooSection dependsOn="enableSASTScan" showOn="true"]
             [@ww.checkbox labelKey="thresholdsEnabled.label" name="globalThresholdsEnabled" descriptionKey="thresholdsEnabled.description" toggle='true' disabled="true" checked='false'/]
             [/@ui.bambooSection]

--- a/src/main/resources/english.properties
+++ b/src/main/resources/english.properties
@@ -72,8 +72,11 @@ filterPatterns.label = Include/Exclude Wildcard Patterns
 generatePDFReport.label = Generate CxSAST PDF Report
 generatePDFReport.description = Downloadable PDF report with scan results from the Checkmarx server. The report is available via a link on "Checkmarx Scan Results" page
 
-enablePolicyViolations.label = Enable Project\'s policy enforcement
+enablePolicyViolations.label = Enable Project\'s SAST and OSA policy enforcement
 enablePolicyViolations.description = Mark the build as failed or unstable if the project's policy is violated. Note: Assigning a policy to a project is done from within CxSAST
+
+enablePolicyViolationsSCA.label = Enable Project\'s SCA policy enforcement
+enablePolicyViolationsSCA.description = Mark the build as failed or unstable if the project's SCA policy is violated. Note: Assigning a policy to a project is done from within SCA
 
 
 thresholdsEnabled.label = Enable CxSAST Vulnerability Thresholds


### PR DESCRIPTION
This PR addresses the following:

**1. [PLUG-1741]: [Bamboo] Policy violations check for SCA scan is not working when policy enforcement flag is enabled.**

- created a separate parameter: "Enable Project's SCA policy enforcement"

- Files updated:
[AgentTaskConfigurator.java]
[CxGlobalConfig.java]
[CheckmarxTask.java]
[CxConfigHelper.java]
[CxParam.java]
[CxPluginUtils.java]
[cxGlobalConfig.ftl]
[editExampleTask.ftl]
[english.properties]

**2. [PLUG-1742]: [Bamboo] Build fails for asynchronous SCA scan for new project.**

- Updated conditions in [CheckmarxTask.java]

**3. [PLUG-1743]: [Bamboo] Dependency Scan is happening even when both Global dependency scan configuration and override global dependency scan setting in config are disabled**

- Added if condition to first check if "Enable Dependency Scan" is enabled in global configurations, then only values of child parameters to be rendered.

- Files updated:
[CxConfigHelper.java]
[CxPluginUtils.java]

---------------------------------------------------------------------------------------------------------------------------------

- Reviewer Requests: **@bebni @ThokalSameer @umeshwaghode** 

[PLUG-1741]: https://checkmarx.atlassian.net/browse/PLUG-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUG-1742]: https://checkmarx.atlassian.net/browse/PLUG-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUG-1743]: https://checkmarx.atlassian.net/browse/PLUG-1743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ