### PR TITLE
 PLUG-1785: [Bamboo] First scan in pipeline should not show report (of previous scan) if scan is asynchronous.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.cx</groupId>
     <artifactId>checkmarx-bamboo-plugin</artifactId>
 
-    <version>2024.1.2</version>
+    <version>2024.1.4</version>
 
     <organization>
         <name>Checkmarx LTD</name>

--- a/src/main/java/com/cx/plugin/task/CheckmarxTask.java
+++ b/src/main/java/com/cx/plugin/task/CheckmarxTask.java
@@ -187,12 +187,13 @@ public class CheckmarxTask implements TaskType {
 			if (!config.getSynchronous()) {
 				log.info("Running in Asynchronous mode. Not waiting for scan to finish.");
 
+				if(config.isSastEnabled() || config.isOsaEnabled() || config.isAstScaEnabled()) {
 				if (generateAsyncReport) {
 					ScanResults finalScanResults = getFinalScanResults(results);
 					String scanHTMLSummary = delegator.generateHTMLSummary(finalScanResults);
 					ret.getSummary().put(HTML_REPORT, scanHTMLSummary);
 					buildContext.getBuildResult().getCustomBuildData().putAll(ret.getSummary());
-
+					
 					if (ret.getException() != null || ret.getGeneralException() != null) {
 						printBuildFailure(null, ret, log);
 						return taskResultBuilder.failed().build();
@@ -200,6 +201,11 @@ public class CheckmarxTask implements TaskType {
 					return taskResultBuilder.success().build();
 				} else {
 					String message = "<br><br><br><b>Job is configured to run Checkmarx scan asynchronously. Previous report not found.</b>";
+					ret.getSummary().put(HTML_REPORT, message);
+					buildContext.getBuildResult().getCustomBuildData().putAll(ret.getSummary());
+				}
+				}else {
+					String message = "<br><br><br><b>Both SAST and Dependency Scan are disabled.</b>";
 					ret.getSummary().put(HTML_REPORT, message);
 					buildContext.getBuildResult().getCustomBuildData().putAll(ret.getSummary());
 				}

--- a/src/main/java/com/cx/plugin/task/CheckmarxTask.java
+++ b/src/main/java/com/cx/plugin/task/CheckmarxTask.java
@@ -199,9 +199,13 @@ public class CheckmarxTask implements TaskType {
 						printBuildFailure(null, ret, log);
 						return taskResultBuilder.failed().build();
 					}
-
+					
 					return taskResultBuilder.success().build();
 					
+				}else {
+					String message= "<br><br><br><b>Job is configured to run Checkmarx scan asynchronously. Previous report not found.</b>";
+					ret.getSummary().put(HTML_REPORT, message);
+					buildContext.getBuildResult().getCustomBuildData().putAll(ret.getSummary());
 				}
 			}
 


### PR DESCRIPTION
This PR addresses the following:

**1. [PLUG-1785](https://checkmarx.atlassian.net/browse/PLUG-1785): [Bamboo] First scan in pipeline should not show report (of previous scan) if scan is asynchronous.**

- CheckmarxTask.java
   Added a flag(generateAsyncReport), in case of asynchronous scan to check, if reports are ready or report of previous scan is available or not, in case flag is false, report name is not generated and method generateHTMLSummary() won't be called.

--------------------------------------------------------------------------------------------------------------------------------

- Reviewer Requests: @bebni @chanducmc @ThokalSameer 

--------------------------------------------------------------------------------------------------------------------------------

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

[PLUG-1785]: https://checkmarx.atlassian.net/browse/PLUG-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ